### PR TITLE
Add fathom analytics script

### DIFF
--- a/includes/index.hbs
+++ b/includes/index.hbs
@@ -19,6 +19,7 @@
   <meta property="og:image" content="flumenCover.png">
 
   <link rel="alternate" type="application/rss+xml" title="{{siteTitle}}" href="{{feedHref}}" />
+  <script src="https://cdn.usefathom.com/script.js" data-site="NADWHFVA" defer></script>
   <link href="index.css" rel="stylesheet" />
 </head>
 


### PR DESCRIPTION
We want to add analytics to the site, so we can see how many people are using the site, approximately where they come from, and a few details about their browser. This is so we can make using the site the best possible experience, including making sure all features work on the different browsers and devices people use. 

Privacy and respect for our users is really important to us, so we are using [Fathom analytics](https://usefathom.com/) for this service - they are completely GDPR-compliant and set no cookies. The [analytics dashboard is publicly accessible](https://app.usefathom.com/share/nadwhfva/flumen) so you can see what information is collected about users.